### PR TITLE
renamed atom-dynamic-macro -> dynamic-macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# atom-dynamic-macro
+# dynamic-macro
 
 * [Atom](https://atom.io/)で[Dynamic Macro](https://github.com/masui/DynamicMacro)を実装してみる
 * JunSuzuki氏の[キーボードマクロパッケージ](http://qiita.com/JunSuzukiJapan/items/692dc5390ec545178e7d)を参考にした
 
 ### 使い方
 
-* ```apm install atom-dynamic-macro```
+* ```apm install dynamic-macro```
 
 ### 問題
 

--- a/keymaps/dynamic-macro.cson
+++ b/keymaps/dynamic-macro.cson
@@ -9,8 +9,8 @@
 # https://atom.io/docs/latest/behind-atom-keymaps-in-depth
 
 #'atom-workspace':
-#  'ctrl-t': 'atom-dynamic-macro:execute'
+#  'ctrl-t': 'dynamic-macro:execute'
 
 '.editor':
   'ctrl-t': 'unset!'
-  'ctrl-t': 'atom-dynamic-macro:execute'
+  'ctrl-t': 'dynamic-macro:execute'

--- a/lib/dynamic-macro.coffee
+++ b/lib/dynamic-macro.coffee
@@ -6,7 +6,7 @@ module.exports = AtomDynamicMacro =
 
   activate: (state) ->
     @subscriptions = new CompositeDisposable
-    @subscriptions.add atom.commands.add 'atom-workspace', 'atom-dynamic-macro:execute': => @execute()
+    @subscriptions.add atom.commands.add 'atom-workspace', 'dynamic-macro:execute': => @execute()
     #
     # package.jsonでactivationをディレイするのをやめて、パッケージロード時にこの初期化処理がすぐ実行されるようにする
     #

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "atom-dynamic-macro",
-  "main": "./lib/atom-dynamic-macro",
+  "name": "dynamic-macro",
+  "main": "./lib/dynamic-macro",
   "version": "0.8.0",
   "description": "Atom version of Dynamic Macro",
   "keywords": [
     "Dynamic Macro"
   ],
   "activationCommands_removed_for_no_delay": {
-    "atom-workspace": "atom-dynamic-macro:execute"
+    "atom-workspace": "dynamic-macro:execute"
   },
-  "repository": "https://github.com/masui/atom-dynamic-macro",
+  "repository": "https://github.com/masui/dynamic-macro",
   "license": "MIT",
   "engines": {
     "atom": ">=1.0.0 <2.0.0"

--- a/spec/dynamic-macro-spec.coffee
+++ b/spec/dynamic-macro-spec.coffee
@@ -1,62 +1,62 @@
-# AtomDynamicMacro = require '../lib/atom-dynamic-macro'
-# 
+# AtomDynamicMacro = require '../lib/dynamic-macro'
+#
 # # Use the command `window:run-package-specs` (cmd-alt-ctrl-p) to run specs.
 # #
 # # To run a specific `it` or `describe` block add an `f` to the front (e.g. `fit`
 # # or `fdescribe`). Remove the `f` to unfocus the block.
-# 
+#
 # describe "AtomDynamicMacro", ->
 #   [workspaceElement, activationPromise] = []
-# 
+#
 #   beforeEach ->
 #     workspaceElement = atom.views.getView(atom.workspace)
-#     activationPromise = atom.packages.activatePackage('atom-dynamic-macro')
-# 
-#   describe "when the atom-dynamic-macro:toggle event is triggered", ->
+#     activationPromise = atom.packages.activatePackage('dynamic-macro')
+#
+#   describe "when the dynamic-macro:toggle event is triggered", ->
 #     it "hides and shows the modal panel", ->
 #       # Before the activation event the view is not on the DOM, and no panel
 #       # has been created
-#       expect(workspaceElement.querySelector('.atom-dynamic-macro')).not.toExist()
-# 
+#       expect(workspaceElement.querySelector('.dynamic-macro')).not.toExist()
+#
 #       # This is an activation event, triggering it will cause the package to be
 #       # activated.
-#       atom.commands.dispatch workspaceElement, 'atom-dynamic-macro:toggle'
-# 
+#       atom.commands.dispatch workspaceElement, 'dynamic-macro:toggle'
+#
 #       waitsForPromise ->
 #         activationPromise
-# 
+#
 #       runs ->
-#         expect(workspaceElement.querySelector('.atom-dynamic-macro')).toExist()
-# 
-#         atomDynamicMacroElement = workspaceElement.querySelector('.atom-dynamic-macro')
+#         expect(workspaceElement.querySelector('.dynamic-macro')).toExist()
+#
+#         atomDynamicMacroElement = workspaceElement.querySelector('.dynamic-macro')
 #         expect(atomDynamicMacroElement).toExist()
-# 
+#
 #         atomDynamicMacroPanel = atom.workspace.panelForItem(atomDynamicMacroElement)
 #         expect(atomDynamicMacroPanel.isVisible()).toBe true
-#         atom.commands.dispatch workspaceElement, 'atom-dynamic-macro:toggle'
+#         atom.commands.dispatch workspaceElement, 'dynamic-macro:toggle'
 #         expect(atomDynamicMacroPanel.isVisible()).toBe false
-# 
+#
 #     it "hides and shows the view", ->
 #       # This test shows you an integration test testing at the view level.
-# 
+#
 #       # Attaching the workspaceElement to the DOM is required to allow the
 #       # `toBeVisible()` matchers to work. Anything testing visibility or focus
 #       # requires that the workspaceElement is on the DOM. Tests that attach the
 #       # workspaceElement to the DOM are generally slower than those off DOM.
 #       jasmine.attachToDOM(workspaceElement)
-# 
-#       expect(workspaceElement.querySelector('.atom-dynamic-macro')).not.toExist()
-# 
+#
+#       expect(workspaceElement.querySelector('.dynamic-macro')).not.toExist()
+#
 #       # This is an activation event, triggering it causes the package to be
 #       # activated.
-#       atom.commands.dispatch workspaceElement, 'atom-dynamic-macro:toggle'
-# 
+#       atom.commands.dispatch workspaceElement, 'dynamic-macro:toggle'
+#
 #       waitsForPromise ->
 #         activationPromise
-# 
+#
 #       runs ->
 #         # Now we can test for view visibility
-#         atomDynamicMacroElement = workspaceElement.querySelector('.atom-dynamic-macro')
+#         atomDynamicMacroElement = workspaceElement.querySelector('.dynamic-macro')
 #         expect(atomDynamicMacroElement).toBeVisible()
-#         atom.commands.dispatch workspaceElement, 'atom-dynamic-macro:toggle'
+#         atom.commands.dispatch workspaceElement, 'dynamic-macro:toggle'
 #         expect(atomDynamicMacroElement).not.toBeVisible()


### PR DESCRIPTION
名前を変更しました。

![image](https://cloud.githubusercontent.com/assets/34204/13008585/81c18864-d1da-11e5-8e58-2a0d8d6ce9a2.png)
