### PR TITLE
Fix two Windows specific issues.

### DIFF
--- a/lib/atom-dynamic-macro.coffee
+++ b/lib/atom-dynamic-macro.coffee
@@ -16,8 +16,10 @@ module.exports = AtomDynamicMacro =
     @seq = []
     handler = (event) ->
       seq = AtomDynamicMacro.seq
-      seq.push(event)
-      seq.shift() if seq.length > 100
+      tailIdentifier = if 0 < seq.length then seq[seq.length-1].keyIdentifier else ""
+      if tailIdentifier != event.keyIdentifier || !AtomDynamicMacro.modifierKey(event)
+        seq.push(event)
+        seq.shift() if seq.length > 100
     document.addEventListener 'keydown', handler, true
 
   deactivate: ->
@@ -75,5 +77,7 @@ module.exports = AtomDynamicMacro =
             editor.insertText(" ")
           else
             atom.keymaps.simulateTextInput(key)
+      else if key.keyIdentifier == "Enter"
+        editor.insertText("\n")
       else
         atom.keymaps.handleKeyboardEvent(key)


### PR DESCRIPTION
  issue1: modifier key events accumulated and make it hart to fire the dynamic macro on Windows
  issue2: Enter key events recorded in the macro do not insert new line characters on Windows

Fix for issue1: discard the key press event if the event is a modifier event and its identifier is same as the one at the tail of seq
Fix for issue2: when replaying Enter key event, insert "\n" rather than calling atom.keymaps.handleKeyboardEvent function
